### PR TITLE
Fixed post.attachments empty causes crash

### DIFF
--- a/Mattermost/Views/Cells/Chat/FeedBaseTableViewCell.swift
+++ b/Mattermost/Views/Cells/Chat/FeedBaseTableViewCell.swift
@@ -68,7 +68,9 @@ class FeedBaseTableViewCell: UITableViewCell, Reusable {
         case .default:
             self.messageLabel.layoutData = post.renderedText
         case .slackAttachment:
-            post.renderedText = AttributedTextLayoutData(text: post.attachments.first!.attributedText!, maxWidth: UIScreen.screenWidth() - Constants.UI.FeedCellMessageLabelPaddings - Constants.UI.PostStatusViewSize)
+            if post.attachments.count > 0 {
+                post.renderedText = AttributedTextLayoutData(text: post.attachments.first!.attributedText!, maxWidth: UIScreen.screenWidth() - Constants.UI.FeedCellMessageLabelPaddings - Constants.UI.PostStatusViewSize)
+            }
         }
         self.messageLabel.layoutData = post.renderedText
     }


### PR DESCRIPTION
And I think it should avoid most force-unwrapping of optionals